### PR TITLE
reqURL.href is now correctly formatted before emitting `request` event. ...

### DIFF
--- a/lib/Proxy.js
+++ b/lib/Proxy.js
@@ -193,6 +193,7 @@ function Proxy(options) {
 			};
 		}
 
+		reqURL.href = url.format(reqURL);
 		self.emit('request', request, response, reqURL);
 
 		if (response.finished || response.isHandledOutside) {


### PR DESCRIPTION
...This brings partial compatibility with older version.

Still, there is now port number in the `href` part of reqURL, even if it's default (80 or 443), which probably will break old hyperProxy overrides.
