### PR TITLE
Fix tunnel to outside proxy.

### DIFF
--- a/lib/Proxy.js
+++ b/lib/Proxy.js
@@ -299,7 +299,15 @@ function Proxy(options) {
 		};
 
 		if (reqURL.proxy) {
-			http.request({host: reqURL.proxy.hostname, port: reqURL.proxy.port, method: 'CONNECT', path: reqURL.href}).on('connect', function(res, socket, head){
+			var reqProxy = {
+				host: reqURL.proxy.hostname,
+				port: reqURL.proxy.port,
+				method: 'CONNECT',
+				path: reqURL.host,
+				headers: reqOptions.headers
+			};
+			reqProxy.headers['X-Forwarded-Proto'] = reqURL.protocol.slice(0, -1);
+			http.request(reqProxy).on('connect', function(res, socket, head){
 				if (reqURL.protocol === 'https:') {
 					reqOptions.socket = socket;
 				}
@@ -394,7 +402,7 @@ function Proxy(options) {
 	this.httpServer.addListener('connect', function(request, socket, head){
 		// Assume that CONNECT is called for HTTPS, unless request.url targets HTTP protocol.
 		var target = url.parse(request.url);
-		var secure = !(target.protocol && target.protocol === 'http:');
+		var secure = (request.headers['x-forwarded-proto'] ? request.headers['x-forwarded-proto'] === 'https' : !(target.protocol && target.protocol === 'http:'));
 
 		// Create certificate before tunneling, so it is ready for our httpsServer to use before client connects.
 		var commonName = request.headers['host'].replace(/:\d+$/, '');


### PR DESCRIPTION
Fix tunnel to outside proxy: it looks like using full href when passing path is not allowed - it should be just a host. Add X-Forwarded-Proto header too, so hyperProxy can decide which way to proxy the request (through internal http or https server).
