### PR TITLE
Prevent re-creating certificate on each request. Creating it once should...

### DIFF
--- a/lib/Proxy.js
+++ b/lib/Proxy.js
@@ -407,11 +407,20 @@ function Proxy(options) {
 		// Create certificate before tunneling, so it is ready for our httpsServer to use before client connects.
 		var commonName = request.headers['host'].replace(/:\d+$/, '');
 
-		if (!secure || !options.useSNI || SNI.hasOwnProperty(commonName)) {
+		if (!secure || !options.useSNI || (SNI.hasOwnProperty(commonName) && SNI[commonName] instanceof Object)) {
 			self.createTunnel(secure, socket, head);
 			return;
 		}
 
+		self.once('SNIReady', function(){
+			self.createTunnel(secure, socket, head);
+		});
+
+		if (SNI[commonName] === true) {
+			return;
+		}
+		
+		SNI[commonName] = true;
 		pem.createCertificate({days: 1, selfSigned: true, organization: 'hyperProxy', commonName: commonName}, function(err, keys){
 			if (err) {
 				console.error(err);
@@ -421,8 +430,8 @@ function Proxy(options) {
 					key: keys.serviceKey,
 					cert: keys.certificate
 				});
-			}
-			self.createTunnel(secure, socket, head);
+				self.emit('SNIReady', commonName);
+			}			
 		});
 	});
 	this.httpServer.addListener('error', self.serverErrorHandler.bind(self.httpServer));

--- a/test/test-proxy.js
+++ b/test/test-proxy.js
@@ -337,7 +337,7 @@ describe('Proxy', function(){
 		});
 	});
 
-	describe.skip('Certificates', function(){
+	describe('Certificates', function(){
 		before(function(done){
 			self.options.useSNI = true;
 
@@ -381,14 +381,14 @@ describe('Proxy', function(){
 				path: self.options.host+':'+self.options.testServerPort
 			}).on('connect', function(res, socket, head) {
 				var ssocket = tls.connect(0, {socket: socket}, function(){
+					var cert = ssocket.getPeerCertificate();
+					assert.strictEqual(cert.subject.O, 'hyperProxy');
+					assert.strictEqual(cert.subject.CN, 'example.com');
+
 					ssocket.write('GET / HTTP/1.1\r\n' +
 						'Host: '+self.options.host+':'+self.options.testServerPort+'\r\n' +
 						'Connection: close\r\n' +
 						'\r\n');
-					var cert = ssocket.getPeerCertificate();
-					//console.log(cert);
-					assert.strictEqual(cert.subject.O, 'hyperProxy');
-					assert.strictEqual(cert.subject.CN, 'example.com');
 				});
 				ssocket.on('data', function(data){});
 				ssocket.on('end', done);


### PR DESCRIPTION
... be enough :).
