### PR TITLE
Fixed running proxy with autogenerated root certificate

### DIFF
--- a/hyperProxy.js
+++ b/hyperProxy.js
@@ -77,8 +77,9 @@ var createFileResponseHandler = require(path.join(path.dirname(module.filename),
  *      //'pacPort': 8002,
  *      'verbose': true,//'debug',
  *
- *      // Defaults to `lib/certs/server.crt` and `lib/certs/server.key`
- * 	    // Set key and cert to `false` to disable HTTPS support.
+ *      // Defaults to autocreated `hyperProxy-root.key` and `hyperProxy-root.crt`,
+ *      // or `lib/certs/server.crt` and `lib/certs/server.key` if creating fails.
+ *      // Set key and cert to `false` to disable HTTPS support.
  *      'key': fs.readFileSync('./certs/ssl-key.pem'), 'utf8'),
  *      'cert': fs.readFileSync('./certs/ssl-cert.pem'), 'utf8'),
  *

--- a/lib/Flags.js
+++ b/lib/Flags.js
@@ -3,9 +3,9 @@ var util = require('util');
 /**
  *	Helper class for working with flags.
  *
- *	Property names of Defines Object will be used as accessors on Flags.
- *	Values of Deifines Objects will be used as constants for flags.
- *	For example:
+ *	Property names of Definitions Object will be used as accessors on Flags.
+ *	Values of Definitions Object will be used as constants for flags.
+ *	For example, with definitions like this:
  *
  *	```
  *	var FLAGS = {
@@ -14,18 +14,18 @@ var util = require('util');
  *	};
  *	```
  *
- *	That will make it possible to work with flags like this:
+ *	You will be able to use Flags object like this:
  *	- `if (flags.one)`
  *	- `flags.one = true`
  *	- `flags.set(FLAGS.one | FLAGS.four)`
  *	- `flags.unset(FLAGS.one | FLAGS.four)`
  *	- `if (flags.isset(FLAGS.one | FLAGS.four))`
  *
- *	You can also update definitions at later time (but be careful: updating definitions does not update the flags state!):
+ *	You can also update definitions at later time (WARNING: updating definitions does not update the flags state!):
  *
  *	```
  *	FLAGS.two = 0x00000002;
- *	flags.updateDefines(FLAGS);
+ *	flags.updateDefinitions(FLAGS);
  *	if (flags.two) {
  *		// ...
  *	}

--- a/lib/MIME.js
+++ b/lib/MIME.js
@@ -66,6 +66,11 @@ var PathToMime = function(filename){
 		if (charset) {
 			result += '; charset=' + charset;
 		}
+
+		// TODO: remove this if/when mime module return proper MIME for OTF fonts.
+		if (result === 'font/opentype') {
+			result = 'application/font-sfnt';
+		}
 	}
 	else {
 		result = TYPES[path.extname(filename).toLowerCase().substring(1)] || 'application/octet-stream';

--- a/lib/Proxy.js
+++ b/lib/Proxy.js
@@ -52,7 +52,8 @@ var createSecureContext = tls.hasOwnProperty('createSecureContext') ? tls.create
  *	// Defaults to `port + 1`.
  *	httpsPort: 8001,
  *	// Use following cert and key for HTTPS.
- *	// Defaults to `lib/certs/server.crt` and `lib/certs/server.key`.
+ *	// Defaults to autocreated `hyperProxy-root.key` and `hyperProxy-root.crt`,
+ *	// or `lib/certs/server.crt` and `lib/certs/server.key` if creating fails.
  *	// Set key and cert to `false` to disable HTTPS support.
  *	key : fs.readFileSync('my_proxy_server.key'), 'utf8'),
  *	cert: fs.readFileSync('my_proxy_server.crt'), 'utf8'),
@@ -278,7 +279,7 @@ function Proxy(options) {
 			var openssl = spawn('openssl', params);
 			var opensslDone = self.whenAllDone.bind(self, {id: 'root-certificate-create', todo: 2, done: 0}, function(){
 				if (code) {
-					console.warn('Could not create root certificate at '+options.certPath);
+					console.warn('Could not create root certificate at '+options.certPath+', defaults from '+CERTS_DIR+' will be used.');
 					options.keyPath = defaultKey;
 					options.certPath = defaultCert;
 				}
@@ -319,7 +320,7 @@ function Proxy(options) {
 		options.keyPath = options.keyPath || tempKey || defaultKey;
 		fs.readFile(options.keyPath, {encoding: 'utf8'}, function(err, data){
 			if (err) {
-				options.key = false;
+				options.key = null;
 			}
 			else {
 				options.key = data;
@@ -331,7 +332,7 @@ function Proxy(options) {
 		options.certPath = options.certPath || tempCert || defaultCert;
 		fs.readFile(options.certPath, {encoding: 'utf8'}, function(err, data){
 			if (err) {
-				options.cert = false;
+				options.cert = null;
 			}
 			else {
 				options.cert = data;

--- a/lib/Proxy.js
+++ b/lib/Proxy.js
@@ -126,7 +126,7 @@ function Proxy(options) {
 
 	options.useSNI    = options.hasOwnProperty('useSNI') ? options.useSNI : !!pem;
 	if (options.useSNI && process.features.tls_sni && !pem) {
-		console.warn('PEM (https://github.com/andris9/pem) module is required on-demand SNI functionality. Please install it: npm install pem');
+		console.warn('PEM (https://github.com/andris9/pem) module is required for on-demand SNI functionality. Please install it: npm install pem');
 		options.useSNI = false;
 	}
 


### PR DESCRIPTION
- Now newly created certificate will be actually used right away, without a need for a restart.
- Small text improvements in descriptions and warning.
- Workaround for incorrect MIME type returned by node-mime module for OTF font file.